### PR TITLE
add ACL support

### DIFF
--- a/README
+++ b/README
@@ -43,6 +43,8 @@ devices:
     fastboot_set_active: true
 
   - board: evb2k
+    users:
+      - username
     console: /dev/ttyUSB0
     fastboot: abcdef3
     fastboot_set_active: true

--- a/cdba-server.c
+++ b/cdba-server.c
@@ -47,6 +47,7 @@
 #include "list.h"
 
 static bool quit_invoked;
+static const char *username;
 
 struct device *selected_device;
 
@@ -121,7 +122,7 @@ static void msg_select_board(const void *param)
 {
 	struct msg reply = { MSG_SELECT_BOARD, 0 };
 
-	selected_device = device_open(param, &fastboot_ops);
+	selected_device = device_open(param, username, &fastboot_ops);
 	if (!selected_device) {
 		fprintf(stderr, "failed to open %s\n", (const char *)param);
 		quit_invoked = true;
@@ -231,10 +232,10 @@ static int handle_stdin(int fd, void *buf)
 			device_send_break(selected_device);
 			break;
 		case MSG_LIST_DEVICES:
-			device_list_devices();
+			device_list_devices(username);
 			break;
 		case MSG_BOARD_INFO:
-			device_info(msg->data, msg->len);
+			device_info(username, msg->data, msg->len);
 			break;
 		default:
 			fprintf(stderr, "unk %d len %d\n", msg->type, msg->len);
@@ -363,6 +364,8 @@ int main(int argc, char **argv)
 	int ret;
 
 	signal(SIGPIPE, sigpipe_handler);
+
+	username = getenv("CDBA_USER");
 
 	ret = device_parser(".cdba");
 	if (ret) {

--- a/device.h
+++ b/device.h
@@ -15,6 +15,7 @@ struct device {
 	char *name;
 	char *serial;
 	char *description;
+	struct list_head *users;
 	unsigned voltage;
 	bool tickle_mmc;
 	bool usb_always_on;
@@ -45,9 +46,17 @@ struct device {
 	struct list_head node;
 };
 
+struct device_user {
+	const char *username;
+
+	struct list_head node;
+};
+
 void device_add(struct device *device);
 
-struct device *device_open(const char *board, struct fastboot_ops *fastboot_ops);
+struct device *device_open(const char *board,
+			   const char *username,
+			   struct fastboot_ops *fastboot_ops);
 void device_close(struct device *dev);
 int device_power(struct device *device, bool on);
 
@@ -60,8 +69,8 @@ void device_boot(struct device *device, const void *data, size_t len);
 void device_fastboot_boot(struct device *device);
 void device_fastboot_flash_reboot(struct device *device);
 void device_send_break(struct device *device);
-void device_list_devices(void);
-void device_info(const void *data, size_t dlen);
+void device_list_devices(const char *username);
+void device_info(const char *username, const void *data, size_t dlen);
 
 enum {
 	DEVICE_KEY_FASTBOOT,

--- a/device_parser.c
+++ b/device_parser.c
@@ -90,6 +90,28 @@ static void parse_board(struct device_parser *dp)
 	dev = calloc(1, sizeof(*dev));
 
 	while (accept(dp, YAML_SCALAR_EVENT, key)) {
+		if (!strcmp(key, "users")) {
+			dev->users = calloc(1, sizeof(*dev->users));
+			list_init(dev->users);
+
+			if (accept(dp, YAML_SCALAR_EVENT, value))
+				continue;
+
+			expect(dp, YAML_SEQUENCE_START_EVENT, NULL);
+
+			while (accept(dp, YAML_SCALAR_EVENT, key)) {
+				struct device_user *user = calloc(1, sizeof(*user));
+
+				user->username = strdup(key);
+
+				list_add(dev->users, &user->node);
+			}
+
+			expect(dp, YAML_SEQUENCE_END_EVENT, NULL);
+
+			continue;
+		}
+
 		expect(dp, YAML_SCALAR_EVENT, value);
 
 		if (!strcmp(key, "board")) {

--- a/shell/cdba-shell
+++ b/shell/cdba-shell
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-user=$1
+export CDBA_USER="$1"
 cmd=${SSH_ORIGINAL_COMMAND%% *}
 
 if [ "$cmd" = "git-upload-pack" -o "$cmd" = "git-receive-pack" ]; then
-	if grep -Fxq $user $HOME/admins ; then
+	if grep -Fxq $CDBA_USER $HOME/admins ; then
 		exec sh -c "$SSH_ORIGINAL_COMMAND"
 	fi
 


### PR DESCRIPTION
Implement ACL support to limit visibility of the boards.  This allows one to e.g. limit visibility of some of the customer boards to the certain groups of users, while keeping the rest of the lab generally visible to all remote cdba users.