### PR TITLE
Support custom reset sequences

### DIFF
--- a/README
+++ b/README
@@ -29,6 +29,12 @@ boot.img.
 == Device configuration
 The list of attached devices is read from $HOME/.cdba and is YAML formatted.
 
+== Custom reset sequence
+
+For devices where power-control is nontrivial, a workaround is to use the soft-reset
+feature built into the board, this usually involves pressing some button combination.
+A custom reset sequence can be specified with the "reset_sequence" YAML key.
+
 === Example
 devices:
   - board: db2k
@@ -54,3 +60,11 @@ devices:
     fastboot: 91671140
     fastboot_set_active: true
     fastboot_key_timeout: 2
+
+  - board: sdm845-enchilada
+    qcomlt_debug_board: /dev/serial/by-id/usb-postmarketOS_Test_Device_E6604430430-if00
+    console: /dev/serial/by-id/usb-postmarketOS_Test_Device_E6604430430-if02
+    name: "OnePlus 6"
+    fastboot: 5725c671
+    # Press power; sleep 10.5 seconds; press vol+; sleep 1 second; release power
+    reset_sequence: "B;10500;R;0;b;0;"

--- a/cdba-server.c
+++ b/cdba-server.c
@@ -417,6 +417,10 @@ int main(int argc, char **argv)
 
 done:
 
+	close(STDIN_FILENO);
+	close(STDOUT_FILENO);
+	close(STDERR_FILENO);
+
 	if (selected_device)
 		device_close(selected_device);
 

--- a/cdba-server.c
+++ b/cdba-server.c
@@ -85,6 +85,8 @@ static void fastboot_opened(struct fastboot *fb, void *data)
 
 	warnx("fastboot connection opened");
 
+	device_fastboot_open(data);
+
 	msg = alloca(sizeof(*msg) + 1);
 	msg->type = MSG_FASTBOOT_PRESENT;
 	msg->len = 1;

--- a/device.c
+++ b/device.c
@@ -112,7 +112,7 @@ found:
 	if (device->usb_always_on)
 		device_usb(device, true);
 
-	device->fastboot = fastboot_open(device->serial, fastboot_ops, NULL);
+	device->fastboot = fastboot_open(device->serial, fastboot_ops, device);
 
 	return device;
 }
@@ -262,6 +262,22 @@ int device_write(struct device *device, const void *buf, size_t len)
 	assert(device->write);
 
 	return device->write(device, buf, len);
+}
+
+void device_fastboot_open(struct device *device)
+{
+	/*
+	 * udev might trigger preemptively or if we're already in fastboot
+	 * in that case just ignore
+	 */
+	if (!device)
+		return;
+
+	// fprintf(stderr, "fastboot opened: %s\n", device->serial);
+
+	/* Release fastboot key if being held */
+	if (device->release_key_on_fastboot_detect)
+		device_key(device, DEVICE_KEY_FASTBOOT, false);
 }
 
 void device_fastboot_boot(struct device *device)

--- a/device.h
+++ b/device.h
@@ -26,6 +26,7 @@ struct device {
 	bool tickle_mmc;
 	bool usb_always_on;
 	bool release_key_on_fastboot_detect;
+	bool power_off_to_fastboot;
 	struct fastboot *fastboot;
 	unsigned int fastboot_key_timeout;
 	int state;
@@ -51,6 +52,7 @@ struct device {
 
 	void (*send_break)(struct device *dev);
 	bool set_active;
+	bool in_fastboot;
 
 	void *cdb;
 

--- a/device.h
+++ b/device.h
@@ -8,6 +8,13 @@ struct cdb_assist;
 struct fastboot;
 struct fastboot_ops;
 
+enum device_key {
+	DEVICE_KEY_FASTBOOT,
+	DEVICE_KEY_POWER,
+};
+
+#define MAX_RESET_SEQUENCE 6
+
 struct device {
 	char *board;
 	char *control_dev;
@@ -22,6 +29,13 @@ struct device {
 	unsigned int fastboot_key_timeout;
 	int state;
 	bool has_power_key;
+	bool custom_reset_sequence;
+	int reset_sequence_count;
+	struct {
+		enum device_key key;
+		bool asserted;
+		unsigned short sleep_ms;
+	} reset_sequence[MAX_RESET_SEQUENCE];
 
 	void (*boot)(struct device *);
 
@@ -62,10 +76,5 @@ void device_fastboot_flash_reboot(struct device *device);
 void device_send_break(struct device *device);
 void device_list_devices(void);
 void device_info(const void *data, size_t dlen);
-
-enum {
-	DEVICE_KEY_FASTBOOT,
-	DEVICE_KEY_POWER,
-};
 
 #endif

--- a/device.h
+++ b/device.h
@@ -25,6 +25,7 @@ struct device {
 	unsigned voltage;
 	bool tickle_mmc;
 	bool usb_always_on;
+	bool release_key_on_fastboot_detect;
 	struct fastboot *fastboot;
 	unsigned int fastboot_key_timeout;
 	int state;
@@ -71,6 +72,7 @@ int device_write(struct device *device, const void *buf, size_t len);
 
 void device_boot(struct device *device, const void *data, size_t len);
 
+void device_fastboot_open(struct device *device);
 void device_fastboot_boot(struct device *device);
 void device_fastboot_flash_reboot(struct device *device);
 void device_send_break(struct device *device);

--- a/device_parser.c
+++ b/device_parser.c
@@ -210,6 +210,8 @@ static void parse_board(struct device_parser *dp)
 			dev->usb_always_on = !strcmp(value, "true");
 		} else if (!strcmp(key, "reset_sequence")) {
 			parse_reset_sequence(dev, value);
+		} else if (!strcmp(key, "release_key_on_fastboot_detect")) {
+			dev->release_key_on_fastboot_detect = true;
 		} else {
 			fprintf(stderr, "device parser: unknown key \"%s\"\n", key);
 			exit(1);

--- a/device_parser.c
+++ b/device_parser.c
@@ -212,6 +212,8 @@ static void parse_board(struct device_parser *dp)
 			parse_reset_sequence(dev, value);
 		} else if (!strcmp(key, "release_key_on_fastboot_detect")) {
 			dev->release_key_on_fastboot_detect = true;
+		} else if (!strcmp(key, "power_off_to_fastboot")) {
+			dev->power_off_to_fastboot = true;
 		} else {
 			fprintf(stderr, "device parser: unknown key \"%s\"\n", key);
 			exit(1);

--- a/qcomlt_dbg.c
+++ b/qcomlt_dbg.c
@@ -88,7 +88,7 @@ void qcomlt_dbg_key(struct device *dev, int key, bool asserted)
 {
 	struct qcomlt_dbg *dbg = dev->cdb;	
 
-	// fprintf(stderr, "qcomlt_dbg_key(%d, %d)\n", key, asserted);
+	fprintf(stderr, "qcomlt_dbg_key(%d, %d)\n", key, asserted);
 
 	switch (key) {
 	case DEVICE_KEY_FASTBOOT:


### PR DESCRIPTION
Where hard power-sequencing is not available, do the next best thing and soft-reset the board via a button combination. As this behaviour isn't consistent between platforms, allow defining a custom reset sequence, as well as holding down the fastboot key until the device is actually detected in fastboot mode.

Deprecates #10 