### PR TITLE
device: support specifying active slot

### DIFF
--- a/device.c
+++ b/device.c
@@ -258,7 +258,7 @@ void device_boot(struct device *device, const void *data, size_t len)
 {
 	warnx("booting the board...");
 	if (device->set_active)
-		fastboot_set_active(device->fastboot, "a");
+		fastboot_set_active(device->fastboot, device->set_active);
 	fastboot_download(device->fastboot, data, len);
 	device->boot(device);
 }

--- a/device.h
+++ b/device.h
@@ -35,7 +35,7 @@ struct device {
 	void (*key)(struct device *device, int key, bool asserted);
 
 	void (*send_break)(struct device *dev);
-	bool set_active;
+	const char *set_active;
 
 	void *cdb;
 

--- a/device_parser.c
+++ b/device_parser.c
@@ -144,7 +144,10 @@ static void parse_board(struct device_parser *dp)
 			if (!dev->boot)
 				dev->boot = device_fastboot_boot;
 		} else if (!strcmp(key, "fastboot_set_active")) {
-			dev->set_active = !strcmp(value, "true");
+			if (!strcmp(value, "true"))
+				dev->set_active = "a";
+			else
+				dev->set_active = strdup(value);
 		} else if (!strcmp(key, "broken_fastboot_boot")) {
 			if (!strcmp(value, "true"))
 				dev->boot = device_fastboot_flash_reboot;


### PR DESCRIPTION
For different reasons it might be desirable to keep slot 'b' as an active slot. Add support for specifying the active slot in the config file. The default is still slot 'a'.