### PR TITLE
cdba-server: Remove dead code

### DIFF
--- a/cdba-server.c
+++ b/cdba-server.c
@@ -304,7 +304,6 @@ static struct timeval *watch_timer_next(void)
 	struct timeval now;
 	struct timer *next;
 	struct timer *t;
-	int count = 0;
 
 	if (list_empty(&timer_watches))
 		return NULL;
@@ -314,7 +313,6 @@ static struct timeval *watch_timer_next(void)
 	list_for_each_entry(t, &timer_watches, node) {
 		if (timercmp(&t->tv, &next->tv, <))
 			next = t;
-		count++;
 	}
 
 	gettimeofday(&now, NULL);


### PR DESCRIPTION
Don't count the timers, as it's not used anywhere. Clang is unhappy with that:

cdba-server.c:307:6: warning: variable 'count' set but not used [-Wunused-but-set-variable]
        int count = 0;