### PR TITLE
ci: use Debian ARM hard-float port instead of armel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,11 +76,11 @@ jobs:
 
           # Debian cross compilation builds
           - container: "debian:testing"
-            arch: armel
-            compiler: arm-linux-gnueabi-gcc
-            cross_compile: arm-linux-gnueabi
+            arch: armhf
+            compiler: arm-linux-gnueabihf-gcc
+            cross_compile: arm-linux-gnueabihf
             variant: cross-compile
-            pkg_config_path: /usr/lib/arm-linux-gnueabi/pkgconfig
+            pkg_config_path: /usr/lib/arm-linux-gnueabihf/pkgconfig
 
           - container: "debian:testing"
             arch: arm64
@@ -104,11 +104,11 @@ jobs:
             pkg_config_path: /usr/lib/s390x-linux-gnu/pkgconfig
 
           - container: "debian:stable"
-            arch: armel
-            compiler: arm-linux-gnueabi-gcc
-            cross_compile: arm-linux-gnueabi
+            arch: armhf
+            compiler: arm-linux-gnueabihf-gcc
+            cross_compile: arm-linux-gnueabihf
             variant: cross-compile
-            pkg_config_path: /usr/lib/arm-linux-gnueabi/pkgconfig
+            pkg_config_path: /usr/lib/arm-linux-gnueabihf/pkgconfig
 
           - container: "debian:stable"
             arch: arm64


### PR DESCRIPTION
Newer ARMv7 boards are actually supported by armhf, not armel.  armel containers might not even work:

  The following packages have unmet dependencies:
    libc6-dev:armel : Depends: linux-libc-dev:armel but it is not installable
  E: Unable to correct problems, you have held broken packages.