### PR TITLE
make: fix compiler detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,17 @@ jobs:
           - ubuntu:jammy
           - ubuntu:focal
           - ubuntu:bionic
-          - ubuntu:xenial
         cross_compile: [""]
         variant: [""]
         include:
+          - container: "ubuntu:xenial"
+            arch: x86-64
+            compiler: cc
+
+          - container: "ubuntu:xenial"
+            arch: x86-64
+            compiler: clang
+
           # Debian 32-bit builds
           - container: "debian:testing"
             arch: i386

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ CFLAGS := $(CFLAGS) -Wextra -Wno-unused-parameter -Wno-unused-result -Wno-missin
 # Few clang version still have warnings so fail only on GCC
 GCC_CFLAGS := -Werror
 GCC_CFLAGS += -Wformat-signedness -Wnull-dereference -Wduplicated-cond -Wduplicated-branches -Wvla-larger-than=1
-GCC_CFLAGS += -Walloc-zero -Wstringop-truncation -Wdouble-promotion -Wshadow -Wunsafe-loop-optimizations
+GCC_CFLAGS += -Walloc-zero -Wdouble-promotion -Wshadow -Wunsafe-loop-optimizations
 GCC_CFLAGS += -Wpointer-arith -Wcast-align -Wwrite-strings -Wlogical-op -Wstrict-overflow=4 -Wundef -Wjump-misses-init
+#GCC_CFLAGS += -Wstringop-truncation # not on Ubuntu bionic, gcc 7.5 doesn't support it
 CLANG_CFLAGS := -Wnull-dereference -Wdouble-promotion -Wshadow -Wpointer-arith -Wwrite-strings -Wstrict-overflow=4 -Wundef
 # TODO:
 # GCC_CFLAGS += -Wcast-qual

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ CLANG_CFLAGS := -Wnull-dereference -Wdouble-promotion -Wshadow -Wpointer-arith -
 # TODO:
 # GCC_CFLAGS += -Wcast-qual
 # CLANG_CFLAGS += -Wcast-qual -Wcast-align
-ifeq ($(CC),cc)
+ifneq (,$(findstring gcc,$(CC)))
   CFLAGS += $(GCC_CFLAGS)
-else ifeq ($(CC),clang)
+else ifneq (,$(findstring clang,$(CC)))
   CFLAGS += $(CLANG_CFLAGS)
 else
   $(info No compiler flags for: $(CC))


### PR DESCRIPTION
Use findstring to determine if gcc or clang is getting used.