### PR TITLE
meson: migrate -Werror into meson's werror option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
       if: ${{ matrix.variant == 'i386' }}
       run: |
         mkdir build
-        CFLAGS="-m32" LDFLAGS="-m32" meson setup . build
+        CFLAGS="-m32" LDFLAGS="-m32" meson setup --werror . build
 
     - name: Meson init with cross compile
       if: ${{ matrix.variant == 'cross-compile' }}
@@ -227,13 +227,13 @@ jobs:
         echo "pkg_config_libdir = '${PKG_CONFIG_PATH}'" >> cross.txt
         cat cross.txt
         mkdir build
-        meson setup --cross-file cross.txt . build
+        meson setup --cross-file cross.txt --werror . build
 
     - name: Meson init
       if: ${{ matrix.variant == '' }}
       run: |
         mkdir build
-        meson setup . build
+        meson setup --werror . build
 
     - name: Compile
       run: ninja -C build

--- a/cdba-server.c
+++ b/cdba-server.c
@@ -158,7 +158,7 @@ void cdba_send_buf(int type, size_t len, const void *buf)
 
 static int handle_stdin(int fd, void *buf)
 {
-	static struct circ_buf recv_buf = { 0 };
+	static struct circ_buf recv_buf = { };
 	struct msg *msg;
 	struct msg hdr;
 	size_t n;

--- a/cdba.c
+++ b/cdba.c
@@ -581,7 +581,7 @@ int main(int argc, char **argv)
 	int timeout_total = 600;
 	struct work *next;
 	struct work *work;
-	struct circ_buf recv_buf = { 0 };
+	struct circ_buf recv_buf = { };
 	const char *board = NULL;
 	const char *host = NULL;
 	struct timeval now;

--- a/meson.build
+++ b/meson.build
@@ -26,8 +26,7 @@ compiler_cflags = ['-Wno-unused-parameter',
 
 # TODO add clang specific options
 if compiler.get_id() == 'gcc'
-	compiler_cflags += ['-Werror',	# Only set it on GCC
-			    '-Wformat-signedness',
+	compiler_cflags += ['-Wformat-signedness',
 			    '-Wduplicated-cond',
 			    '-Wduplicated-branches',
 			    '-Wvla-larger-than=1',


### PR DESCRIPTION
Follow Meson recomendations and use --werror option instead of hardcoding -Werror.