### PR TITLE
Add Alpine Linux CI and stop enabling werror for everyone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
       if: ${{ matrix.variant == 'i386' }}
       run: |
         mkdir build
-        CFLAGS="-m32" LDFLAGS="-m32" meson setup . build
+        CFLAGS="-m32" LDFLAGS="-m32" meson setup --errorlogs --werror . build
 
     - name: Meson init with cross compile
       if: ${{ matrix.variant == 'cross-compile' }}
@@ -228,13 +228,13 @@ jobs:
         echo "pkg_config_libdir = '${PKG_CONFIG_PATH}'" >> cross.txt
         cat cross.txt
         mkdir build
-        meson setup --cross-file cross.txt . build
+        meson setup --errorlogs --werror --cross-file cross.txt . build
 
     - name: Meson init
       if: ${{ matrix.variant == '' }}
       run: |
         mkdir build
-        meson setup . build
+        meson setup --errorlogs --werror . build
 
     - name: Compile
       run: ninja -C build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
         family: [x86-64]
         compiler: [gcc, clang]
         container:
+          - alpine:edge
+          - alpine:latest
           - archlinux:latest
           - debian:testing
           - debian:stable

--- a/cdba-server.c
+++ b/cdba-server.c
@@ -158,7 +158,7 @@ void cdba_send_buf(int type, size_t len, const void *buf)
 
 static int handle_stdin(int fd, void *buf)
 {
-	static struct circ_buf recv_buf = { 0 };
+	static struct circ_buf recv_buf = { };
 	struct msg *msg;
 	struct msg hdr;
 	size_t n;

--- a/cdba.c
+++ b/cdba.c
@@ -581,7 +581,7 @@ int main(int argc, char **argv)
 	int timeout_total = 600;
 	struct work *next;
 	struct work *work;
-	struct circ_buf recv_buf = { 0 };
+	struct circ_buf recv_buf = { };
 	const char *board = NULL;
 	const char *host = NULL;
 	struct timeval now;

--- a/ci/alpine.sh
+++ b/ci/alpine.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (c) 2021 Canonical Ltd.
+# Copyright (c) 2023 Linaro Ltd
+# Author: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+#                             <krzk@kernel.org>
+#
+
+set -ex
+
+PKGS_CC="gcc"
+case $CC in
+	clang*)
+		PKGS_CC="clang"
+	;;
+esac
+
+apk add \
+	linux-headers \
+	libftdi1-dev \
+	yaml-dev \
+	eudev-dev \
+	meson \
+	musl-dev \
+	libc-dev \
+	$PKGS_CC
+
+echo "Install finished: $0"

--- a/meson.build
+++ b/meson.build
@@ -26,8 +26,7 @@ compiler_cflags = ['-Wno-unused-parameter',
 
 # TODO add clang specific options
 if compiler.get_id() == 'gcc'
-	compiler_cflags += ['-Werror',	# Only set it on GCC
-			    '-Wformat-signedness',
+	compiler_cflags += ['-Wformat-signedness',
 			    '-Wduplicated-cond',
 			    '-Wduplicated-branches',
 			    '-Wvla-larger-than=1',


### PR DESCRIPTION
Enabling -Werror by default sucks for everyone who isn't maintaining
CDBA. By all means we should enable it in CI, but not for users and
not for folks packaging it in distros.

Remove it from the flags in meson.build, and use mesons built in option
to enable it only in CI.

See:
https://embeddedartistry.com/blog/2017/05/22/werror-is-not-your-friend/

I plan to package CDBA in Alpine soon, having build tests for it in CI will help ensure that we avoid easy regressions like missing headers (yay musl..)