### PR TITLE
local_gpio: simplify yaml description

### DIFF
--- a/README
+++ b/README
@@ -66,21 +66,21 @@ devices:
     console: /dev/serial/by-id/usb-1234-if00-port0
     name: GPIO controller board
     local_gpio:
-      - power:
-          chip: gpiochip0
-          line: 7
-          active_low: true
-      - fastboot_key:
-          chip: gpiochip0
-          line: 8
-          active_low: true
-      - power_key:
-          chip: gpiochip0
-          line: 14
-          active_low: true
-      - usb_disconnect:
-          chip: gpiochip1
-          line: 4
+      power:
+        chip: gpiochip0
+        line: 7
+        active_low: true
+      fastboot_key:
+        chip: gpiochip0
+        line: 8
+        active_low: true
+      power_key:
+        chip: gpiochip0
+        line: 14
+        active_low: true
+      usb_disconnect:
+        chip: gpiochip1
+        line: 4
     fastboot: cacafada
     fastboot_set_active: true
     fastboot_key_timeout: 2

--- a/local-gpio.c
+++ b/local-gpio.c
@@ -54,15 +54,13 @@ void *local_gpio_parse_options(struct device_parser *dp)
 	char value[TOKEN_LENGTH];
 	char key[TOKEN_LENGTH];
 
-	device_parser_expect(dp, YAML_SEQUENCE_START_EVENT, NULL, 0);
+	device_parser_expect(dp, YAML_MAPPING_START_EVENT, NULL, 0);
 
 	options = calloc(1, sizeof(*options));
 
 	/* Loop over sub-properties */
-	while (device_parser_accept(dp, YAML_MAPPING_START_EVENT, NULL, 0)) {
+	while (device_parser_accept(dp, YAML_SCALAR_EVENT, key, TOKEN_LENGTH)) {
 		int gpio_id;
-
-		device_parser_accept(dp, YAML_SCALAR_EVENT, key, TOKEN_LENGTH);
 
 		if (!strcmp(key, "power")) {
 			gpio_id = GPIO_POWER;
@@ -98,11 +96,9 @@ void *local_gpio_parse_options(struct device_parser *dp)
 		device_parser_expect(dp, YAML_MAPPING_END_EVENT, NULL, 0);
 
 		options->gpios[gpio_id].present = true;
-
-		device_parser_expect(dp, YAML_MAPPING_END_EVENT, NULL, 0);
 	}
 
-	device_parser_expect(dp, YAML_SEQUENCE_END_EVENT, NULL, 0);
+	device_parser_expect(dp, YAML_MAPPING_END_EVENT, NULL, 0);
 
 	return options;
 }


### PR DESCRIPTION
As discussed in https://github.com/linux-msm/cdba/pull/46#discussion_r1379831140:

Instead of:
```
    local_gpio:
      - power: 
          chip: gpiochip0
          line: 7
          active_low: true
      - fastboot_key:
          chip: gpiochip0
          line: 8
          active_low: true
      - power_key:
          chip: gpiochip0
          line: 14
          active_low: true
      - usb_disconnect:
          chip: gpiochip1
          line: 4
```

Accept the following:
```
    local_gpio:
      power:
        chip: gpiochip0
        line: 7
        active_low: true
      fastboot_key:
        chip: gpiochip0
        line: 8
        active_low: true
      power_key:
        chip: gpiochip0
        line: 14
        active_low: true
      usb_disconnect:
        chip: gpiochip1
        line: 4
```

It's simpler and clearer.