### PR TITLE
cdba-server: add CDBA-server banner to be output on startup

### DIFF
--- a/cdba-server.c
+++ b/cdba-server.c
@@ -356,6 +356,8 @@ int main(int argc, char **argv)
 
 	signal(SIGPIPE, sigpipe_handler);
 
+	fprintf(stderr, "Starting cdba server\n");
+
 	username = getenv("CDBA_USER");
 	if (!username)
 		username = getenv("USER");


### PR DESCRIPTION
Granted all possible issues with SSH, especially in the remote and/or proxied labs, and possible issues with the board being present but failing to power up, it is useful to have a banner message once CDBA was started. This gives user a clear picture that the connection is fine and the server is trying to power up the board.