### PR TITLE
Clean trailing white-spaces

### DIFF
--- a/cdb_assist.c
+++ b/cdb_assist.c
@@ -100,7 +100,7 @@ static void cdb_parser_bool(struct cdb_assist *cdb, const char *key, bool set)
 	for (i = 0; i < 5; i++)
 		if (strcmp(key, sz_keys[i]) == 0)
 			break;
-	
+
 	switch (i) {
 	case 0:
 		cdb->vbat = set;
@@ -126,7 +126,7 @@ static void cdb_parser_voltage(struct cdb_assist *cdb, unsigned set, unsigned ac
 	cdb->voltage_actual = actual;
 	cdb->voltage_set = set;
 }
-			
+
 static void cdb_parser_vref(struct cdb_assist *cdb, unsigned vref)
 {
 	cdb->vref = vref;
@@ -224,7 +224,7 @@ static void cdb_parser_push(struct cdb_assist *cdb, char ch)
 	case STATE_key_of:
 		if (ch == 'f')
 			cdb_parser_bool(cdb, cdb->key, false);
-		cdb->state = STATE_;	
+		cdb->state = STATE_;
 		break;
 	case STATE_key_value:
 		if (isdigit(ch)) {

--- a/fastboot.c
+++ b/fastboot.c
@@ -325,7 +325,7 @@ unref_dev:
 
 	return 0;
 }
-	
+
 struct fastboot *fastboot_open(const char *serial, struct fastboot_ops *ops, void *data)
 {
 	struct fastboot *fb;
@@ -345,9 +345,9 @@ struct fastboot *fastboot_open(const char *serial, struct fastboot_ops *ops, voi
 	fb->serial = serial;
 	fb->ops = ops;
 	fb->data = data;
-	
+
 	fb->state = FASTBOOT_STATE_START;
-	
+
 	fb->mon = udev_monitor_new_from_netlink(udev, "udev");
 	udev_monitor_filter_add_match_subsystem_devtype(fb->mon, "usb", NULL);
 	udev_monitor_enable_receiving(fb->mon);

--- a/qcomlt_dbg.c
+++ b/qcomlt_dbg.c
@@ -85,7 +85,7 @@ static void *qcomlt_dbg_open(struct device *dev)
 
 static int qcomlt_dbg_power(struct device *dev, bool on)
 {
-	struct qcomlt_dbg *dbg = dev->cdb;	
+	struct qcomlt_dbg *dbg = dev->cdb;
 
 	// fprintf(stderr, "qcomlt_dbg_power(%d)\n", on);
 	return write(dbg->fd, &("pP"[on]), 1);
@@ -93,7 +93,7 @@ static int qcomlt_dbg_power(struct device *dev, bool on)
 
 static void qcomlt_dbg_usb(struct device *dev, bool on)
 {
-	struct qcomlt_dbg *dbg = dev->cdb;	
+	struct qcomlt_dbg *dbg = dev->cdb;
 
 	// fprintf(stderr, "qcomlt_dbg_usb(%d)\n", on);
 	write(dbg->fd, &("uU"[on]), 1);
@@ -101,7 +101,7 @@ static void qcomlt_dbg_usb(struct device *dev, bool on)
 
 static void qcomlt_dbg_key(struct device *dev, int key, bool asserted)
 {
-	struct qcomlt_dbg *dbg = dev->cdb;	
+	struct qcomlt_dbg *dbg = dev->cdb;
 
 	// fprintf(stderr, "qcomlt_dbg_key(%d, %d)\n", key, asserted);
 


### PR DESCRIPTION
Drop trailing white-spaces and tabs.  No functional changes.