### PR TITLE
ci: switch to new libftdi on Arch Linux

### DIFF
--- a/ci/archlinux.sh
+++ b/ci/archlinux.sh
@@ -17,7 +17,7 @@ case $CC in
 esac
 
 pacman -Syu --noconfirm \
-	libftdi-compat \
+	libftdi \
 	libyaml \
 	systemd-libs \
 	libgpiod \


### PR DESCRIPTION
Use latest (not compat) version of libftdi in install scripts for Arch Linux.