### PR TITLE
Fix quitting if the board is locked

### DIFF
--- a/cdba-server.c
+++ b/cdba-server.c
@@ -201,6 +201,11 @@ static void sigpipe_handler(int signo)
 	watch_quit();
 }
 
+static void atexit_handler(void)
+{
+	syslog(LOG_INFO, "exiting");
+}
+
 int main(int argc, char **argv)
 {
 	int flags;
@@ -217,6 +222,7 @@ int main(int argc, char **argv)
 		username = "nobody";
 
 	openlog("cdba-server", LOG_PID, LOG_DAEMON);
+	atexit(atexit_handler);
 
 	ret = device_parser(".cdba");
 	if (ret) {

--- a/cdba-server.c
+++ b/cdba-server.c
@@ -216,7 +216,7 @@ int main(int argc, char **argv)
 	if (!username)
 		username = "nobody";
 
-	openlog("cdba-server", 0, LOG_DAEMON);
+	openlog("cdba-server", LOG_PID, LOG_DAEMON);
 
 	ret = device_parser(".cdba");
 	if (ret) {


### PR DESCRIPTION
cdba-server blocks if the board is locked by another session. Loop around the flock(), sleeping in the middle. This allows CDBA to break early if user closes the terminal (by killing SSH or by Ctrl-A-Q sequence).