### PR TITLE
ftdi_gpio: Turn on OUTPUT_ENABLE first

### DIFF
--- a/drivers/ftdi-gpio.c
+++ b/drivers/ftdi-gpio.c
@@ -311,15 +311,15 @@ static void *ftdi_gpio_open(struct device *dev)
 	if (ftdi_gpio->options->gpios[GPIO_POWER_KEY].present)
 		dev->has_power_key = true;
 
+	if (ftdi_gpio->options->gpios[GPIO_OUTPUT_ENABLE].present)
+		ftdi_gpio_toggle_io(ftdi_gpio, GPIO_OUTPUT_ENABLE, 1);
+
 	ftdi_gpio_device_power(ftdi_gpio, 0);
 
 	if (dev->usb_always_on)
 		ftdi_gpio_device_usb(ftdi_gpio, 1);
 	else
 		ftdi_gpio_device_usb(ftdi_gpio, 0);
-
-	if (ftdi_gpio->options->gpios[GPIO_OUTPUT_ENABLE].present)
-		ftdi_gpio_toggle_io(ftdi_gpio, GPIO_OUTPUT_ENABLE, 1);
 
 	usleep(500000);
 


### PR DESCRIPTION
Observed instability in controlling devices when OUTPUT_ENABLE wasn't enabled in the first step. I couldn't find any documented reason why this is, but the documentation does say: "FtdiOutput Pin always kept at 1".

Alpaca always keeps OUTUT_ENABLE as 1, and never turns it off. The documentation seems to imply it should always be left on. This change updates the open sequence so that the OUTPUT_ENABLE bit is set first.