### PR TITLE
cdba: Rely on fastboot completion rather than USB disconnect

### DIFF
--- a/cdba.c
+++ b/cdba.c
@@ -533,13 +533,11 @@ static int handle_message(struct circ_buf *buf)
 				} else {
 					quit = true;
 				}
-			} else {
-				fastboot_done = true;
-				// printf("======================================== MSG_FASTBOOT_PRESENT(off)\n");
 			}
 			break;
 		case MSG_FASTBOOT_DOWNLOAD:
 			// printf("======================================== MSG_FASTBOOT_DOWNLOAD\n");
+			fastboot_done = true;
 			break;
 		case MSG_FASTBOOT_BOOT:
 			// printf("======================================== MSG_FASTBOOT_BOOT\n");
@@ -556,6 +554,7 @@ static int handle_message(struct circ_buf *buf)
 			break;
 		case MSG_FASTBOOT_CONTINUE:
 			// printf("======================================== MSG_FASTBOOT_CONTINUE\n");
+			fastboot_done = true;
 			break;
 		default:
 			fprintf(stderr, "unk %d len %d\n", msg->type, msg->len);


### PR DESCRIPTION
The purpose for providing different exit codes (2 vs 110) for timeout before or after fastboot was to allow tools invoking cdba to detect if the device arrived at and performed fastboot or not.

In most cases relying on the fastboot (USB) disconnect notification works fine, but in cases where the provided image fails to decompress the standard fastboot implementation will OKAY the transfer, fail to process the image and then return to process further fastboot requests.

This has been observed in cases where the image is too big, or when it contains a big endian kernel.

Change the logic to rely on the "FASTBOOT_DOWNLOAD" response to determine that we did reach fastboot and where able to upload the image and then something happened - i.e. "there's a problem with the image" vs "there's a setup problem".