### PR TITLE
cdba: Add keys to remotely press power or fastboot key

### DIFF
--- a/cdba.h
+++ b/cdba.h
@@ -31,6 +31,24 @@ enum {
 	MSG_LIST_DEVICES,
 	MSG_BOARD_INFO,
 	MSG_FASTBOOT_CONTINUE,
+	MSG_KEY_PRESS,
+};
+
+struct key_press {
+	uint8_t key;
+	uint8_t state;
+} __packed;
+
+enum {
+	DEVICE_KEY_FASTBOOT,
+	DEVICE_KEY_POWER,
+	DEVICE_KEY_COUNT
+};
+
+enum {
+	KEY_PRESS_RELEASE,
+	KEY_PRESS_PRESS,
+	KEY_PRESS_PULSE,
 };
 
 #endif

--- a/device.c
+++ b/device.c
@@ -163,7 +163,7 @@ static void device_impl_power(struct device *device, bool on)
 	device_control(device, power, on);
 }
 
-static void device_key(struct device *device, int key, bool asserted)
+void device_key(struct device *device, int key, bool asserted)
 {
 	if (device_has_control(device, key))
 		device_control(device, key, key, asserted);

--- a/device.h
+++ b/device.h
@@ -2,6 +2,7 @@
 #define __DEVICE_H__
 
 #include <termios.h>
+#include "cdba.h"
 #include "list.h"
 
 struct cdb_assist;
@@ -76,6 +77,7 @@ struct device *device_open(const char *board,
 			   const char *username);
 void device_close(struct device *dev);
 int device_power(struct device *device, bool on);
+void device_key(struct device *device, int key, bool asserted);
 
 void device_status_enable(struct device *device);
 void device_usb(struct device *device, bool on);
@@ -92,11 +94,6 @@ void device_list_devices(const char *username);
 void device_info(const char *username, const void *data, size_t dlen);
 void device_fastboot_continue(struct device *device);
 bool device_is_running(struct device *device);
-
-enum {
-	DEVICE_KEY_FASTBOOT,
-	DEVICE_KEY_POWER,
-};
 
 extern const struct control_ops alpaca_ops;
 extern const struct control_ops cdb_assist_ops;


### PR DESCRIPTION
Add special keys to allow triggering power and fastboot key presses from the cdba client. There is an option to send a short key "pulse" (press followed by release after 100ms) or to press/release keys separately:

 - ctrl+a -> o: Send power key pulse
 - ctrl+a -> O: Toggle power key (first use: press, next use: release)
 - ctrl+a -> f: Send fastboot key pulse
 - ctrl+a -> F: Toggle fastboot key (first use: press, next use: release)

In most cases you want to send the "pulse" (short key press), so it's helpful to have this mapped to a single key. This avoids forgetting to release the key again after pressing it.

The protocol between CDBA client and server is:

    (MSG_KEY_PRESS <key:u8, state:u8>)

where key is either DEVICE_KEY_FASTBOOT (0) or DEVICE_KEY_POWER (1) and state is either KEY_PRESS_RELEASE (0), KEY_PRESS_PRESS (1) or KEY_PRESS_PULSE (2).

The reason for implementing the "pulse" on the server side is that it's hard to guarantee the timing on the client side. We don't know exactly when the packets will arrive on the server. Also, "state" is a full byte anyway, so might as well use some of the extra bits. :-)

---

Closes #64 (probably, if only power/fastboot key were meant). Also replaces #74. This PR has kind of the requested protocol changes there, plus some other functionality changes (also implement sending power key presses, add key "pulses").