### PR TITLE
drivers: ftdi-gpio: Add second USB disconnect GPIO & schema.yaml fixes

### DIFF
--- a/config-samples/sample8.yaml
+++ b/config-samples/sample8.yaml
@@ -73,3 +73,32 @@ devices:
       power:
         interface: D
         line: 6
+  - board: myboard-5
+    name: "My Board 5"
+    description: |
+      My super awesome board Number 5
+    console: /dev/ttyABC1
+    fastboot: cacafada
+    ftdi_gpio:
+      vendor: "0x0403"
+      product: "0x6011"
+      index: 0
+      power:
+        interface: B
+        line: 1
+        active_low: true
+      fastboot_key:
+        interface: B
+        line: 0
+        active_low: true
+      power_key:
+        interface: B
+        line: 2
+      usb0_disconnect:
+        interface: C
+        line: 7
+        active_low: true
+      usb1_disconnect:
+        interface: A
+        line: 4
+        active_low: true

--- a/drivers/ftdi-gpio.c
+++ b/drivers/ftdi-gpio.c
@@ -31,7 +31,8 @@ enum {
 	GPIO_POWER = 0,			// Power input enable
 	GPIO_FASTBOOT_KEY,		// Usually volume key
 	GPIO_POWER_KEY,			// Key to power the device
-	GPIO_USB_DISCONNECT,		// Simulate main USB connection
+	GPIO_USB0_DISCONNECT,		// Simulate main USB connection
+	GPIO_USB1_DISCONNECT,		// Simulate secondary USB connection
 	GPIO_OUTPUT_ENABLE,		// Enable FTDI signals to flow to the board
 	GPIO_COUNT
 };
@@ -131,7 +132,7 @@ static void ftdi_gpio_parse_config(struct ftdi_gpio_options *options, char *valu
 		else if (strncmp("POWER_KEY", name, off - name - 1) == 0)
 			gpio_type = GPIO_POWER_KEY;
 		else if (strncmp("USB_DISCONNECT", name, off - name - 1) == 0)
-			gpio_type = GPIO_USB_DISCONNECT;
+			gpio_type = GPIO_USB0_DISCONNECT;
 		else if (strncmp("OUTPUT_ENABLE", name, off - name - 1) == 0)
 			gpio_type = GPIO_OUTPUT_ENABLE;
 		else
@@ -182,7 +183,11 @@ void *ftdi_gpio_parse_options(struct device_parser *dp)
 		} else if (!strcmp(key, "power_key")) {
 			gpio_id = GPIO_POWER_KEY;
 		} else if (!strcmp(key, "usb_disconnect")) {
-			gpio_id = GPIO_USB_DISCONNECT;
+			gpio_id = GPIO_USB0_DISCONNECT;
+		} else if (!strcmp(key, "usb0_disconnect")) {
+			gpio_id = GPIO_USB0_DISCONNECT;
+		} else if (!strcmp(key, "usb1_disconnect")) {
+			gpio_id = GPIO_USB1_DISCONNECT;
 		} else if (!strcmp(key, "output_enable")) {
 			gpio_id = GPIO_OUTPUT_ENABLE;
 		} else {
@@ -357,7 +362,8 @@ static int ftdi_gpio_device_power(struct ftdi_gpio *ftdi_gpio, bool on)
 
 static void ftdi_gpio_device_usb(struct ftdi_gpio *ftdi_gpio, bool on)
 {
-	ftdi_gpio_toggle_io(ftdi_gpio, GPIO_USB_DISCONNECT, on);
+	ftdi_gpio_toggle_io(ftdi_gpio, GPIO_USB0_DISCONNECT, on);
+	ftdi_gpio_toggle_io(ftdi_gpio, GPIO_USB1_DISCONNECT, on);
 }
 
 static int ftdi_gpio_power(struct device *dev, bool on)

--- a/schema.yaml
+++ b/schema.yaml
@@ -138,7 +138,7 @@ properties:
         local_gpio:
           description: Local GPIO
           type: object
-          unevaluatedItems: false
+          additionalProperties: false
           patternProperties:
             "^power|fastboot_key|power_key|usb_disconnect$":
               $ref: "#/$defs/local_gpio"
@@ -146,7 +146,7 @@ properties:
         laurent:
           description: KernelChip Laurent relays
           type: object
-          unevaluatedItems: false
+          additionalProperties: false
           properties:
             server:
               type: string

--- a/schema.yaml
+++ b/schema.yaml
@@ -123,9 +123,10 @@ properties:
                   minimin: 0
                 devicenode:
                   $ref: "#/$defs/device_path"
-                patternProperties:
-                  "^power|fastboot_key|power_key|usb_disconnect|output_enable$":
-                    $ref: "#/$defs/ftdi_gpio"
+              patternProperties:
+                "^power|fastboot_key|power_key|usb_disconnect|output_enable$":
+                  $ref: "#/$defs/ftdi_gpio"
+              additionalProperties: false
 
               dependentRequired:
                 index:

--- a/schema.yaml
+++ b/schema.yaml
@@ -124,7 +124,7 @@ properties:
                 devicenode:
                   $ref: "#/$defs/device_path"
               patternProperties:
-                "^power|fastboot_key|power_key|usb_disconnect|output_enable$":
+                "^power|fastboot_key|power_key|usb[01]?_disconnect|output_enable$":
                   $ref: "#/$defs/ftdi_gpio"
               additionalProperties: false
 


### PR DESCRIPTION
Some boards have more than one USB port. In that case, there is a second
GPIO on the debug board to simulate a USB disconnection for those.

Add the option to describe both USB disconnect GPIOs using
"usb0_disconnect" and "usb1_disconnect" and change both of them
when disabling USB power.

In the future it might be useful to control them separately, but for now
this ensures that power to the board is cut properly when the board is
powered off.

Also fix some mistakes in `schema.yaml` that prevented actually validating the properties below `ftdi_gpio`.

Cc: @superna9999 