### PR TITLE
cdba: Add option to run cdba-server locally without ssh and without timeout

### DIFF
--- a/README
+++ b/README
@@ -19,11 +19,12 @@ from sandbox/cdba/cdba-server. Available devices are read from $HOME/.cdba
 = Client side
 The client is invoked as:
 
-  cdba -b <board> -h <host> [-c <power-cylce-count>] [-s <status-fifo>] boot.img
+  cdba -b <board> -h <host> [-c <power-cylce-count>] [-s <status-fifo>] [boot.img]
 
 <host> will be connected to using ssh and <board> will be selected for
-operation. As the board's fastboot interface shows up the given boot.img will
-be transfered and booted on the device.
+operation. As the board's fastboot interface shows up the given boot.img
+will be transfered and booted on the device. If [boot.img] is omitted,
+"fastboot continue" is run to boot the installed operating system.
 
 The board will execute until the key sequence ^A q is invoked or the board
 outputs a sequence of 20 ~ (tilde) chards in a row.

--- a/README
+++ b/README
@@ -19,11 +19,12 @@ from sandbox/cdba/cdba-server. Available devices are read from $HOME/.cdba
 = Client side
 The client is invoked as:
 
-  cdba -b <board> -h <host> [-c <power-cylce-count>] [-s <status-fifo>] [boot.img]
+  cdba -b <board> [-h <host>] [-c <power-cylce-count>] [-s <status-fifo>] [boot.img]
 
 <host> will be connected to using ssh and <board> will be selected for
 operation. As the board's fastboot interface shows up the given boot.img
-will be transfered and booted on the device. If [boot.img] is omitted,
+will be transfered and booted on the device. If <host> is omitted, the
+cdba-server is started locally without using ssh. If [boot.img] is omitted,
 "fastboot continue" is run to boot the installed operating system.
 
 The board will execute until the key sequence ^A q is invoked or the board

--- a/cdba.c
+++ b/cdba.c
@@ -584,7 +584,7 @@ static void usage(void)
 	extern const char *__progname;
 
 	fprintf(stderr, "usage: %s -b <board> -h <host> [-t <timeout>] "
-			"[-T <inactivity-timeout>] <boot.img>\n",
+			"[-T <inactivity-timeout>] [boot.img]\n",
 			__progname);
 	fprintf(stderr, "usage: %s -i -b <board> -h <host>\n",
 			__progname);

--- a/cdba.c
+++ b/cdba.c
@@ -103,7 +103,7 @@ static int fork_ssh(const char *host, const char *cmd, int *pipes)
 		close(piped_stderr[0]);
 		close(piped_stderr[1]);
 
-		execl("/usr/bin/ssh", "ssh", host, cmd, NULL);
+		execlp("ssh", "ssh", host, cmd, NULL);
 		err(1, "launching ssh failed");
 	default:
 		close(piped_stdin[0]);

--- a/cdba.c
+++ b/cdba.c
@@ -103,8 +103,13 @@ static int fork_ssh(const char *host, const char *cmd, int *pipes)
 		close(piped_stderr[0]);
 		close(piped_stderr[1]);
 
-		execlp("ssh", "ssh", host, cmd, NULL);
-		err(1, "launching ssh failed");
+		if (host) {
+			execlp("ssh", "ssh", host, cmd, NULL);
+			err(1, "launching ssh failed");
+		} else {
+			execlp(cmd, cmd, NULL);
+			err(1, "launching cdba-server failed");
+		}
 	default:
 		close(piped_stdin[0]);
 		close(piped_stdout[1]);
@@ -583,12 +588,12 @@ static void usage(void)
 {
 	extern const char *__progname;
 
-	fprintf(stderr, "usage: %s -b <board> -h <host> [-t <timeout>] "
+	fprintf(stderr, "usage: %s -b <board> [-h <host>] [-t <timeout>] "
 			"[-T <inactivity-timeout>] [boot.img]\n",
 			__progname);
-	fprintf(stderr, "usage: %s -i -b <board> -h <host>\n",
+	fprintf(stderr, "usage: %s -i -b <board> [-h <host>]\n",
 			__progname);
-	fprintf(stderr, "usage: %s -l -h <host>\n",
+	fprintf(stderr, "usage: %s -l [-h <host>]\n",
 			__progname);
 	exit(1);
 }
@@ -666,9 +671,6 @@ int main(int argc, char **argv)
 			usage();
 		}
 	}
-
-	if (!host)
-		usage();
 
 	switch (verb) {
 	case CDBA_BOOT:


### PR DESCRIPTION
I use CDBA for booting remote boards, but also sometimes to boot locally attached boards. In that case, the SSH tunnel is pointless (and I don't have a SSH server set up on my laptop). Add an option to start the cdba-server locally without SSH if the host is omitted.

Also add an option to disable the total timeout (`-t 0`). I also sometimes use CDBA to power on a personal board remotely. Without specifying a boot.img, it boots into my installed Linux distro and then I access it via SSH. In that case, I don't want the board to power off while still being logged in.

See commit log for details.