### PR TITLE
laurent: add support for controlling USB power

### DIFF
--- a/cdba-server.c
+++ b/cdba-server.c
@@ -59,9 +59,9 @@ static void msg_select_board(const void *param)
 	if (!selected_device) {
 		fprintf(stderr, "failed to open %s\n", (const char *)param);
 		watch_quit();
+	} else {
+		device_fastboot_open(selected_device, &fastboot_ops);
 	}
-
-	device_fastboot_open(selected_device, &fastboot_ops);
 
 	cdba_send(MSG_SELECT_BOARD);
 }

--- a/device.c
+++ b/device.c
@@ -285,7 +285,7 @@ void device_usb(struct device *device, bool on)
 {
 	if (device->ppps_path)
 		ppps_power(device, on);
-	else if (device_has_control(device, usb))
+	if (device_has_control(device, usb))
 		device_control(device, usb, on);
 }
 

--- a/schema.yaml
+++ b/schema.yaml
@@ -152,6 +152,8 @@ properties:
               type: string
             relay:
               type: integer
+            usb_relay:
+              type: integer
             password:
               description: password to access the relays, defaults to 'Laurent'
               type: string


### PR DESCRIPTION
It is possible to use Laurent relays to control USB mode, e.g. by attaching the relay to the onboard DIP switch on RB1 / RB2 boards. Extend the driver to support such configurations.