### PR TITLE
cdba: read stdin even when it is not a tty

### DIFF
--- a/cdba.c
+++ b/cdba.c
@@ -501,7 +501,7 @@ static int tty_callback(int *ssh_fds)
 	ssize_t n;
 
 	n = read(STDIN_FILENO, buf, sizeof(buf));
-	if (n < 0)
+	if (n <= 0)
 		return n;
 
 	for (k = 0; k < n; k++) {
@@ -553,7 +553,7 @@ static int tty_callback(int *ssh_fds)
 		}
 	}
 
-	return 0;
+	return n;
 }
 
 /**
@@ -909,6 +909,7 @@ int main(int argc, char **argv)
 	struct timeval timeout_total_tv;
 	struct timeval *timeout = NULL;
 	struct termios *orig_tios;
+	bool watch_stdin = true;
 	const char *server_binary = "cdba-server";
 	const char *status_pipe = NULL;
 	bool bump_inactivity_timer;
@@ -1054,7 +1055,7 @@ int main(int argc, char **argv)
 		FD_SET(ssh_fds[2], &rfds);
 		nfds = MAX(ssh_fds[1], ssh_fds[2]);
 
-		if (orig_tios) {
+		if (watch_stdin) {
 			FD_SET(STDIN_FILENO, &rfds);
 
 			nfds = MAX(nfds, STDIN_FILENO);
@@ -1092,8 +1093,10 @@ int main(int argc, char **argv)
 
 		bump_inactivity_timer = false;
 
-		if (FD_ISSET(STDIN_FILENO, &rfds))
-			tty_callback(ssh_fds);
+		if (watch_stdin && FD_ISSET(STDIN_FILENO, &rfds)) {
+			if (tty_callback(ssh_fds) <= 0)
+				watch_stdin = false;
+		}
 
 		if (FD_ISSET(ssh_fds[2], &rfds)) {
 			n = read(ssh_fds[2], buf, sizeof(buf));


### PR DESCRIPTION
Automating cdba is currently impossible without allocating a pty for it, and
the failure gives no hint as to why: the board boots, console output arrives,
and every keystroke written to a fifo or a pipe on stdin is dropped in
silence. It reads as a board that ignores input, so the time goes into
suspecting the target rather than the tool.

The intent to support this case is already in the tree — 7c12435aae39 added
the ENOTTY tolerance so cdba could be launched from cron — but the select loop
reuses the "we changed the termios and must restore it" pointer as its "should
we watch stdin" flag, which quietly withdraws it again.

Wiring cdba into CI, test harnesses and agent-driven workflows is the
motivation; needing a pty to send a single line to a board is a sharp edge
that each such user has to rediscover.

Verified against a DB820c over a plain fifo with stdout redirected to a file
and no pty involved.
